### PR TITLE
raise the default ReceiveMTU to 1500

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -6,8 +6,9 @@ package webrtc
 import "github.com/pion/dtls/v3"
 
 const (
-	// Equal to UDP MTU
-	receiveMTU = 1460
+	// default as the standard ethernet MTU
+	// can be overwritten with SettingEngine.SetReceiveMTU()
+	receiveMTU = 1500
 
 	// simulcastProbeCount is the amount of RTP Packets
 	// that handleUndeclaredSSRC will read and try to dispatch from


### PR DESCRIPTION
#### Description
Raise the default ReceiveMTU to 1500, as same as the default MTU setting of WebRTC.
This is because some senders, i.e. FFmpeg, may packetize RTP with 1460 payload + 12 RTP header + etc.

#### Reference issue
Fixes #2927 
